### PR TITLE
Fix typo in cleanup comment

### DIFF
--- a/build-deb-package.sh
+++ b/build-deb-package.sh
@@ -492,7 +492,7 @@ FILE
 
 chmod +x $PRERM
 
-# create the post clenanup script that disables the service
+# create the post cleanup script that disables the service
 # TODO: remove files related to cardano-node and cardano-db-sync
 cat > $POSTRM << FILE
 #!/bin/sh


### PR DESCRIPTION
## Summary
- correct a typo in `build-deb-package.sh`

## Testing
- `npm test` *(fails: no tests specified)*
- `go test ./...` *(fails to download modules)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d9fdd548833092c2d8f4120c53ac