### PR TITLE
Add unit tests for chunk id parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "vite build",
     "build:package": "pnpm build:package:deb",
     "build:package:deb": "./build-deb-package.sh",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "go test ./..."
   },
   "keywords": [],
   "author": "",

--- a/src/backend/store_test.go
+++ b/src/backend/store_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestExtractChunkID(t *testing.T) {
+	tests := []struct {
+		path    string
+		want    uint32
+		wantErr bool
+	}{
+		{"00001.secondary", 1, false},
+		{"/var/db/00001.secondary", 1, false},
+		{"blocks-0002.dat", 2, false},
+		{"/tmp/blocks-0002.dat", 2, false},
+		{"/files/blocks-0010.other", 10, false},
+		{"bad", 0, true},
+		{"blocks-xyz.dat", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := extractChunkID(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s", tt.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.path, err)
+			}
+			if got != tt.want {
+				t.Errorf("for %s got %d want %d", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `store_test.go` covering `extractChunkID`
- allow running Go tests via npm script

## Testing
- `go test ./...` *(fails: unable to download Go toolchain due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6857dc4fb6ec833099fcdd645995c831