### PR TITLE
Add mempool endpoint

### DIFF
--- a/src/backend/mempool.go
+++ b/src/backend/mempool.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -52,4 +53,24 @@ func (m *Mempool) Prune() {
 			delete(m.txs, h)
 		}
 	}
+}
+
+// Hashes returns the list of transaction hashes currently in the mempool.
+func (m *Mempool) Hashes() []string {
+	if m == nil {
+		return nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	hashes := make([]string, 0, len(m.txs))
+
+	for h := range m.txs {
+		hashes = append(hashes, h)
+	}
+
+	sort.Strings(hashes)
+
+	return hashes
 }

--- a/src/backend/routes.go
+++ b/src/backend/routes.go
@@ -122,6 +122,8 @@ func (h *Handler) api(w http.ResponseWriter, r *http.Request, url URLHelper) {
 		h.parameters(w, r)
 	case "policy":
 		h.policy(w, r, url)
+	case "mempool":
+		h.mempoolTxs(w, r)
 	case "tx":
 		h.tx(w, r, url)
 	case "utxo":
@@ -760,6 +762,19 @@ func (h *Handler) utxoContent(w http.ResponseWriter, r *http.Request, txID strin
 
 		respondWithCBORWithStatus(w, r, cbor, code)
 	}
+}
+
+func (h *Handler) mempoolTxs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		invalidMethod(w, r)
+		return
+	}
+
+	h.mempool.Prune()
+
+	hashes := h.mempool.Hashes()
+
+	respondWithJSON(w, hashes)
 }
 
 func (h *Handler) page(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- expose a new `/api/mempool` endpoint to list transaction hashes
- keep a sorted list of hashes through a new `Hashes` method

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68583640ac78833096a76c813ae20ebc