### PR TITLE
ci: deploy dist artifacts to pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,4 +35,19 @@ jobs:
           go-version: '1.24'
       - run: pnpm install
       - run: pnpm build
+      - name: Write version to dist/latest
+        run: node -e "const fs=require('fs'); const v=require('./package.json').version; fs.mkdirSync('dist',{recursive:true}); fs.writeFileSync('dist/latest', v);"
       - run: pnpm test
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: './dist'
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,16 +38,17 @@ jobs:
       - name: Write version to dist/latest
         run: node -e "const fs=require('fs'); const v=require('./package.json').version; fs.mkdirSync('dist',{recursive:true}); fs.writeFileSync('dist/latest', v);"
       - run: pnpm test
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist'
   deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Write version to dist/latest
         run: node -e "const fs=require('fs'); const v=require('./package.json').version; fs.mkdirSync('dist',{recursive:true}); fs.writeFileSync('dist/latest', v);"
       - run: pnpm test
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
   deploy:
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/src/backend/mempool.go
+++ b/src/backend/mempool.go
@@ -43,6 +43,9 @@ func (m *Mempool) AddTx(tx ledger.Transaction, ttl time.Time) {
 
 // Returns nil if not found
 func (m *Mempool) GetTx(txID string) ledger.Transaction {
+	if m == nil {
+		return nil
+	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 


### PR DESCRIPTION
## Summary
- deploy `dist` directory to GitHub Pages
- add step to write current version to `dist/latest`

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685864906bf88330a6c046bb7fe19469