### PR TITLE
Add remote package deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_ED25519_KEY: ${{ secrets.DEPLOY_ED25519_KEY }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -38,6 +42,18 @@ jobs:
       - name: Write version to dist/latest
         run: node -e "const fs=require('fs'); const v=require('./package.json').version; fs.mkdirSync('dist',{recursive:true}); fs.writeFileSync('dist/latest', v);"
       - run: pnpm test
+      - name: Deploy package to server
+        if: env.DEPLOY_ED25519_KEY != ''
+        run: |
+          echo "$DEPLOY_ED25519_KEY" > key
+          chmod 600 key
+          VERSION=$(cat dist/latest)
+          scp -i key -o StrictHostKeyChecking=no dist/cardano-iris-$VERSION.deb $DEPLOY_USER@$DEPLOY_HOST:
+      - name: Test install remotely
+        if: env.DEPLOY_ED25519_KEY != ''
+        run: |
+          VERSION=$(cat dist/latest)
+          ssh -i key -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST "sudo dpkg -i cardano-iris-$VERSION.deb"
       - uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'


### PR DESCRIPTION
## Summary
- export `DEPLOY_ED25519_KEY`, `DEPLOY_HOST` and `DEPLOY_USER` in `deploy.yml`
- scp the generated deb file to the server and install it remotely during deploy

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858700e313883308370bc9a662bba71