### PR TITLE
Add delay before integ tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           VERSION=$(cat dist/latest)
           ssh -i key -o StrictHostKeyChecking=no $USER@$HOST "sudo dpkg -i cardano-iris-$VERSION.deb"
+      - name: Wait for remote install to finish
+        run: sleep 20
       - name: Enforce IPv4 Connectivity
         uses: ./.github/actions/force-ipv4
       - name: Run integ tests


### PR DESCRIPTION
## Summary
- after installing cardano-iris in the deploy workflow, wait 20 seconds

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858f8eb89cc8330bb0ef3bca02be355