### PR TITLE
Add coin selection endpoint

### DIFF
--- a/src/backend/coinselector.go
+++ b/src/backend/coinselector.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type CoinSelector struct {
+	mu     sync.Mutex
+	locked map[string]time.Time
+}
+
+func NewCoinSelector() *CoinSelector {
+	return &CoinSelector{locked: make(map[string]time.Time)}
+}
+
+func (cs *CoinSelector) pruneExpired() {
+	now := time.Now()
+	for k, v := range cs.locked {
+		if now.After(v) {
+			delete(cs.locked, k)
+		}
+	}
+}
+
+func (cs *CoinSelector) isLocked(key string) bool {
+	ttl, ok := cs.locked[key]
+	return ok && time.Now().Before(ttl)
+}
+
+func (cs *CoinSelector) lock(key string, ttl time.Duration) {
+	cs.locked[key] = time.Now().Add(ttl)
+}
+
+func utxoKey(u UTXO) string {
+	return fmt.Sprintf("%s%d", u.TxID, u.OutputIndex)
+}


### PR DESCRIPTION
## Summary
- add `CoinSelector` with lock tracking
- return UTXOs in `selectUTXOs`
- share UTXO retrieval via `getAddressUTXOs`
- handle POST requests for `/address/{addr}/utxos` for coin selection

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68591ddda4c48330b0e98bfcec56ce77