### PR TITLE
Add collateral UTXO to network parameters

### DIFF
--- a/src/backend/cli.go
+++ b/src/backend/cli.go
@@ -261,6 +261,7 @@ func (c *CardanoCLI) DeriveParameters() (HeliosNetworkParams, error) {
 		TxFeeFixed:           params.TxFeeFixed,
 		TxFeePerByte:         params.TxFeePerByte,
 		UTXODepositPerByte:   params.UTXOCostPerByte,
+		CollateralUTXO:       "",
 	}
 
 	return heliosParams, nil


### PR DESCRIPTION
## Summary
- expose an optional `CollateralUTXO` field in `HeliosNetworkParams`
- initialize `CollateralUTXO` to an empty string in `DeriveParameters`
- fill `CollateralUTXO` from the configured collateral UTXO if it still exists on the wallet's enterprise address
- fix the JSON field name for `CollateralUTXO`

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685d9df83930833080563e6ba97158c3