### PR TITLE
Add automatic collateral signing

### DIFF
--- a/src/backend/walletaddr.go
+++ b/src/backend/walletaddr.go
@@ -8,16 +8,24 @@ import (
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
-func firstEnterpriseAddress(words []string, network string) (string, error) {
+func firstEnterpriseAddressKey(words []string) (crypto.XPrvKey, error) {
 	mnemonic := strings.Join(words, " ")
 	entropy, err := bip39.EntropyFromMnemonic(mnemonic)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	root := crypto.NewXPrvKeyFromEntropy(entropy, "")
 	account := root.Derive(1852 + 0x80000000).Derive(1815 + 0x80000000).Derive(0x80000000)
 	chain := account.Derive(0)
 	addrKey := chain.Derive(0)
+	return addrKey, nil
+}
+
+func firstEnterpriseAddress(words []string, network string) (string, error) {
+	addrKey, err := firstEnterpriseAddressKey(words)
+	if err != nil {
+		return "", err
+	}
 	payment, err := cg.NewKeyCredential(addrKey.PubKey())
 	if err != nil {
 		return "", err
@@ -31,4 +39,12 @@ func firstEnterpriseAddress(words []string, network string) (string, error) {
 		return "", err
 	}
 	return addr.Bech32(), nil
+}
+
+func firstEnterprisePrvKey(words []string) (crypto.PrvKey, error) {
+	addrKey, err := firstEnterpriseAddressKey(words)
+	if err != nil {
+		return nil, err
+	}
+	return addrKey.PrvKey(), nil
 }


### PR DESCRIPTION
## Summary
- auto-sign transactions spending configured collateral UTXO
- expose first enterprise private key helper
- ensure collateral ID parsing matches config file

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685da2a05d4c833090434defaf7b419d