### PR TITLE
Fix tx envelope type

### DIFF
--- a/src/backend/routes.go
+++ b/src/backend/routes.go
@@ -795,11 +795,11 @@ func (h *Handler) submitTx(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// save the tx JSON representation to a temporary file
-	txEnv := TxEnvelope{
-		hex.EncodeToString(txBytes),
-		"Witnessed Tx ConwayEra", // TODO: automatic updating during hardforks
-		"Submitted through the Helios gateway",
-	}
+       txEnv := TxEnvelope{
+               hex.EncodeToString(txBytes),
+               "Tx ConwayEra", // TODO: automatic updating during hardforks
+               "Submitted through the Helios gateway",
+       }
 
 	content, err := json.Marshal(txEnv)
 	if err != nil {


### PR DESCRIPTION
## Summary
Updated the transaction envelope type to `Tx ConwayEra` when submitting a transaction, ensuring the node parses the CBOR correctly.

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685db524b4b88330b863bd64ac14c43e